### PR TITLE
Finish error handlers

### DIFF
--- a/include/insight/insight_errno.h
+++ b/include/insight/insight_errno.h
@@ -2,7 +2,6 @@
 #define INSIGHT_ERRNO_H_
 
 #include <stdio.h>
-#include <errno.h>
 
 /* Copied from gsl_errno.h */
 enum {

--- a/include/insight/insight_errno.h
+++ b/include/insight/insight_errno.h
@@ -47,6 +47,8 @@ enum {
 // Similar to std:strerror()
 const char* insight_strerror(const int insight_errno);
 
+/* STREAM HANDLER */
+
 // Insight stream handler type
 typedef void (insight_stream_handler_t)(const char*, const char*, int, const char*);
 
@@ -72,5 +74,30 @@ FILE* insight_set_stream(FILE* new_stream);
 // (default to stderr).
 void insight_stream_printf(const char* label, const char* file, int line,
                            const char* reason);
+
+/* ERROR HANDLER */
+
+// Insight error handler type
+typedef void (insight_error_handler_t)(const char* reason, const char* file,
+                                       int line, int insight_errno);
+
+// Sets the global variable `insight_error_handler` to the `new_handler` and
+// returns the previous handler.
+insight_error_handler_t*
+insight_set_error_handler(insight_error_handler_t* new_handler);
+
+// Sets the global variable `insight_error_handler` to the "do nothing" handler
+// and returns the previous handler.
+insight_error_handler_t* insight_set_error_handler_off(void);
+
+// If the global variable `insight_error_handler` is not NULL, then this
+// function is equivalent to invoking
+//
+//   `insight_error_handler(reason, file, line, insight_errno)`
+//
+// Otherwise, it flushes the output to stderr.
+void insight_error(const char* reason, const char* file, int line,
+                   int insight_errno);
+
 
 #endif /* INSIGHT_ERRNO_H_ */

--- a/include/insight/insight_errno.h
+++ b/include/insight/insight_errno.h
@@ -98,5 +98,27 @@ insight_error_handler_t* insight_set_error_handler_off(void);
 void insight_error(const char* reason, const char* file, int line,
                    int insight_errno);
 
+/* CONVINIENT MACROS */
+
+// INSIGHT_ERROR: call the error handler, and return the error code
+#define INSIGHT_ERROR(reason, insight_errno)                    \
+  do {                                                          \
+    insight_error(reason, __FILE__, __LINE__, insight_errno);   \
+    return insight_errno;                                       \
+  } while (0)
+
+// INSIGHT_ERROR_VAL: call the error handler, and return the given value
+#define INSIGHT_ERROR_VAL(reason, insight_errno, value)         \
+  do {                                                          \
+    insight_error(reason, __FILE__, __LINE__, insight_errno);   \
+    return value;                                               \
+  } while (0)
+
+// INSIGHT_ERROR_VOID: call the error handler, and return.
+#define INSIGHT_ERROR_VOID(reason, insight_errno)               \
+  do {                                                          \
+    insight_error(reason, __FILE__, __LINE__, insight_errno);   \
+    return;                                                     \
+  } while (0)
 
 #endif /* INSIGHT_ERRNO_H_ */

--- a/include/insight/insight_errno.h
+++ b/include/insight/insight_errno.h
@@ -101,24 +101,24 @@ insight_error(const char* reason, const char* file, int line, int error_code);
 /* CONVINIENT MACROS */
 
 // INSIGHT_ERROR: call the error handler, and return the error code
-#define INSIGHT_ERROR(reason, error_code)                    \
-  do {                                                          \
-    insight_error(reason, __FILE__, __LINE__, error_code);   \
-    return error_code;                                       \
+#define INSIGHT_ERROR(reason, error_code)                   \
+  do {                                                      \
+    insight_error(reason, __FILE__, __LINE__, error_code);  \
+    return error_code;                                      \
   } while (0)
 
 // INSIGHT_ERROR_VAL: call the error handler, and return the given value
-#define INSIGHT_ERROR_VAL(reason, error_code, value)         \
-  do {                                                          \
-    insight_error(reason, __FILE__, __LINE__, error_code);   \
-    return value;                                               \
+#define INSIGHT_ERROR_VAL(reason, error_code, value)        \
+  do {                                                      \
+    insight_error(reason, __FILE__, __LINE__, error_code);  \
+    return value;                                           \
   } while (0)
 
 // INSIGHT_ERROR_VOID: call the error handler, and return.
-#define INSIGHT_ERROR_VOID(reason, error_code)               \
-  do {                                                          \
-    insight_error(reason, __FILE__, __LINE__, error_code);   \
-    return;                                                     \
+#define INSIGHT_ERROR_VOID(reason, error_code)              \
+  do {                                                      \
+    insight_error(reason, __FILE__, __LINE__, error_code);  \
+    return;                                                 \
   } while (0)
 
 #endif /* INSIGHT_ERRNO_H_ */

--- a/include/insight/insight_errno.h
+++ b/include/insight/insight_errno.h
@@ -44,7 +44,7 @@ enum {
 
 
 // Similar to std:strerror()
-const char* insight_strerror(const int insight_errno);
+const char* insight_strerror(const int error_code);
 
 /* STREAM HANDLER */
 
@@ -78,7 +78,7 @@ void insight_stream_printf(const char* label, const char* file, int line,
 
 // Insight error handler type
 typedef void (insight_error_handler_t)(const char* reason, const char* file,
-                                       int line, int insight_errno);
+                                       int line, int error_code);
 
 // Sets the global variable `insight_error_handler` to the `new_handler` and
 // returns the previous handler.
@@ -92,32 +92,32 @@ insight_error_handler_t* insight_set_error_handler_off(void);
 // If the global variable `insight_error_handler` is not NULL, then this
 // function is equivalent to invoking
 //
-//   `insight_error_handler(reason, file, line, insight_errno)`
+//   `insight_error_handler(reason, file, line, error_code)`
 //
 // Otherwise, it flushes the output to stderr.
-void insight_error(const char* reason, const char* file, int line,
-                   int insight_errno);
+void
+insight_error(const char* reason, const char* file, int line, int error_code);
 
 /* CONVINIENT MACROS */
 
 // INSIGHT_ERROR: call the error handler, and return the error code
-#define INSIGHT_ERROR(reason, insight_errno)                    \
+#define INSIGHT_ERROR(reason, error_code)                    \
   do {                                                          \
-    insight_error(reason, __FILE__, __LINE__, insight_errno);   \
-    return insight_errno;                                       \
+    insight_error(reason, __FILE__, __LINE__, error_code);   \
+    return error_code;                                       \
   } while (0)
 
 // INSIGHT_ERROR_VAL: call the error handler, and return the given value
-#define INSIGHT_ERROR_VAL(reason, insight_errno, value)         \
+#define INSIGHT_ERROR_VAL(reason, error_code, value)         \
   do {                                                          \
-    insight_error(reason, __FILE__, __LINE__, insight_errno);   \
+    insight_error(reason, __FILE__, __LINE__, error_code);   \
     return value;                                               \
   } while (0)
 
 // INSIGHT_ERROR_VOID: call the error handler, and return.
-#define INSIGHT_ERROR_VOID(reason, insight_errno)               \
+#define INSIGHT_ERROR_VOID(reason, error_code)               \
   do {                                                          \
-    insight_error(reason, __FILE__, __LINE__, insight_errno);   \
+    insight_error(reason, __FILE__, __LINE__, error_code);   \
     return;                                                     \
   } while (0)
 

--- a/internal/insight/errno.c
+++ b/internal/insight/errno.c
@@ -3,6 +3,11 @@
 // Global variables
 FILE* insight_stream = NULL;
 insight_stream_handler_t* insight_stream_handler = NULL;
+insight_error_handler_t* insight_error_handler = NULL;
+
+// The error handler that does nothing.
+/* static void no_error_handler(const char* reason, const char* file, int line, */
+/*                              int insight_errno); */
 
 const char* insight_strerror(const int gsl_errno) {
   switch (gsl_errno) {
@@ -111,4 +116,11 @@ void insight_stream_printf(const char* label, const char* file, int line,
   }
 
   fprintf(insight_stream, "insight: %s:%d: %s: %s\n", file, line, label, reason);
+}
+
+insight_error_handler_t*
+insight_set_error_handler(insight_error_handler_t* new_handler) {
+  insight_error_handler_t* previous_handler = insight_error_handler;
+  insight_error_handler = new_handler;
+  return previous_handler;
 }

--- a/internal/insight/errno.c
+++ b/internal/insight/errno.c
@@ -7,8 +7,8 @@ insight_stream_handler_t* insight_stream_handler = NULL;
 insight_error_handler_t* insight_error_handler = NULL;
 
 // The error handler that does nothing.
-static void no_error_handler(const char* reason, const char* file, int line,
-                             int insight_errno);
+static void
+no_error_handler(const char* reason, const char* file, int line, int error_code);
 
 const char* insight_strerror(const int gsl_errno) {
   switch (gsl_errno) {
@@ -132,10 +132,10 @@ insight_error_handler_t* insight_set_error_handler_off(void) {
   return previous_handler;
 }
 
-void insight_error(const char* reason, const char* file, int line,
-                   int insight_errno) {
+void
+insight_error(const char* reason, const char* file, int line, int error_code) {
   if (insight_error_handler) {
-    (*insight_error_handler)(reason, file, line, insight_errno);
+    (*insight_error_handler)(reason, file, line, error_code);
     return;
   }
 
@@ -148,12 +148,12 @@ void insight_error(const char* reason, const char* file, int line,
   abort();
 }
 
-static void no_error_handler(const char* reason, const char* file, int line,
-                             int insight_errno) {
+static void
+no_error_handler(const char* reason, const char* file, int line, int error_code) {
   // Do nothing
   (void) reason;
   (void) file;
   (void) line;
-  (void) insight_errno;
+  (void) error_code;
   return;
 }

--- a/internal/insight/errno_test.c
+++ b/internal/insight/errno_test.c
@@ -262,7 +262,7 @@ static void errno_unknown(void** state) {
   assert_string_equal(actual_str, expected_str);
 }
 
-/* STREAM */
+/* STREAM HANDLER */
 
 static void old_stream_handler(const char*  label, const char*  file, int line,
                                const char*  reason) {
@@ -311,6 +311,38 @@ static void test_insight_set_stream(void** state) {
   assert_ptr_equal(insight_stream, stderr);
 }
 
+/* ERROR HANDLER */
+
+static void old_error_handler(const char* reason, const char* file, int line,
+                              int insight_errno) {
+  // Do nothing.
+  (void) reason;
+  (void) file;
+  (void) line;
+  (void) insight_errno;
+}
+
+static void new_error_handler(const char* reason, const char* file, int line,
+                              int insight_errno) {
+  // Do nothing.
+  (void) reason;
+  (void) file;
+  (void) line;
+  (void) insight_errno;
+}
+
+static void test_insight_set_error_handler(void** state) {
+  (void) state;
+  extern insight_error_handler_t* insight_error_handler;
+
+  insight_set_error_handler(&old_error_handler);
+  assert_ptr_equal(insight_error_handler, &old_error_handler);
+
+  insight_error_handler_t* ret = insight_set_error_handler(&new_error_handler);
+  assert_ptr_equal(ret, &old_error_handler);
+  assert_ptr_equal(insight_error_handler, &new_error_handler);
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(errno_success),
@@ -350,7 +382,8 @@ int main(void) {
     cmocka_unit_test(errno_eof),
     cmocka_unit_test(errno_unknown),
     cmocka_unit_test(test_insight_set_stream_handler),
-    cmocka_unit_test(test_insight_set_stream)
+    cmocka_unit_test(test_insight_set_stream),
+    cmocka_unit_test(test_insight_set_error_handler)
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
1. Define the type `insight_error_handler_t` and the global variable `insight_error_handler`.
2. Implement setter for `insight_error_handler`.
3. Implement `insight_error` for reporting errors.
4. Define some convenient macros such as:
    - `INSIGHT_ERROR(reason, error_code)`: call the error handler, and return the error code.
    - `INSIGHT_ERROR_VAL(reason, error_code, value)`: call the error handler, and return the given value.
    - `INSIGHT_ERROR_VOID(reason, error_code)`: call the error handler, and return.
5. Add tests.