### PR TITLE
reading-and-writing-vector-from-and-to-streams

### DIFF
--- a/include/ins/vector/ins_vector_double.h
+++ b/include/ins/vector/ins_vector_double.h
@@ -180,4 +180,33 @@ void ins_vector_minmax_index(const ins_vector * v,
                              size_t * imin_out,
                              size_t * imax_out);
 
+/* Reading and writing vectors
+   -----------------------------------------------------------------------*/
+
+// Reads into the vector `v` from the open stream `stream` in binary format.
+// The vector `v` must be preallocated with the correct length since the
+// function uses the size of `v` to determine how many bytes to read.
+// The return value is `INS_SUCCESS` for success and `INS_EFAILED` if there
+// was a problem reading from the file.
+int ins_vector_fread(ins_vector *v, FILE *stream);
+
+// Writes the elements of the vector `v` to the stream `stream` in binary
+// format. The return value is `INS_SUCCESS` for success and `INS_EFAILED`
+// if there was a problem writing to the file.
+int ins_vector_fwrite(const ins_vector *v, FILE *stream);
+
+// Writes the elements of the vector `v` line-by-line to the open stream
+// `stream` using the format specifier `format`, which should be one of
+// `%g`, `%e`, or `%f` formats for floating point numbers and `%d` for
+// integers. The function returns `INS_SUCCESS` for success and `INS_EFAILED`
+// if there was a problem writing to the file.
+int ins_vector_fprintf(const ins_vector *v, FILE *stream, const char *format);
+
+// Reads formatted data from the stream `stream` into the vector `v`. The
+// vector `v` must be preallocated with the correct length since the function
+// uses the size of `v` to determine how many bytes to read. The function
+// returns `INS_SUCCESS` for success and `INS_EFAILED` if there was a problem
+// reading from the file.
+int ins_vector_fscanf(ins_vector *v, FILE *stream);
+
 #endif  // INS_VECTOR_DOUBLE_H_

--- a/internal/ins/CMakeLists.txt
+++ b/internal/ins/CMakeLists.txt
@@ -15,7 +15,8 @@ set(INSIGHT_SRCS
   block/init.c
   vector/init.c
   vector/oper.c
-  vector/minmax.c)
+  vector/minmax.c
+  vector/file.c)
 
 # Depend on private header files so that they appear in IDEs.
 file(GLOB INSIGHT_INTERNAL_HDRS
@@ -93,4 +94,5 @@ if(BUILD_TESTING)
   ins_test(vector vector_double_init)
   ins_test(vector vector_double_oper)
   ins_test(vector vector_double_minmax)
+  ins_test(vector vector_double_file)
 endif()

--- a/internal/ins/vector/file.c
+++ b/internal/ins/vector/file.c
@@ -1,0 +1,7 @@
+#include "ins/ins_vector.h"
+
+#define INS_USE_NUMERIC_TYPE_DOUBLE
+#include "ins/templates_on.h"
+#include "ins/vector/file_source.c"
+#include "ins/templates_off.h"
+#undef INS_USE_NUMERIC_TYPE_DOUBLE

--- a/internal/ins/vector/file_source.c
+++ b/internal/ins/vector/file_source.c
@@ -75,3 +75,21 @@ int INS_VECTOR_FUNC(fprintf)(const INS_VECTOR_TYPE *v,
 
   return INS_SUCCESS;
 }
+
+int INS_VECTOR_FUNC(fscanf)(INS_VECTOR_TYPE *v, FILE *stream) {
+  const size_t size = v->size;
+  const size_t stride = v->stride;
+  INS_NUMERIC_TYPE * const data = v->data;
+
+  size_t i;
+  INS_NUMERIC_TYPE tmp;
+
+  for (i = 0; i < size; ++i) {
+    if (fscanf(stream, INS_NUMERIC_INPUT_FORMAT, &tmp) != 1) {
+      INS_ERROR("fscanf failed", INS_EFAILED);
+    }
+    data[i * stride] = tmp;
+  }
+
+  return INS_SUCCESS;
+}

--- a/internal/ins/vector/file_source.c
+++ b/internal/ins/vector/file_source.c
@@ -53,3 +53,25 @@ int INS_VECTOR_FUNC(fwrite)(const INS_VECTOR_TYPE *v, FILE *stream) {
 
   return INS_SUCCESS;
 }
+
+int INS_VECTOR_FUNC(fprintf)(const INS_VECTOR_TYPE *v,
+                             FILE *stream,
+                             const char *format) {
+  const size_t size = v->size;
+  const size_t stride = v->stride;
+  const INS_NUMERIC_TYPE *data = v->data;
+
+  size_t i;
+
+  for (i = 0; i < size; ++i) {
+    if (fprintf(stream, format, data[i * stride]) < 0) {
+      INS_ERROR("fprintf failed", INS_EFAILED);
+    }
+
+    if (putc('\n', stream) == EOF) {
+      INS_ERROR("putc failed", INS_EFAILED);
+    }
+  }
+
+  return INS_SUCCESS;
+}

--- a/internal/ins/vector/file_source.c
+++ b/internal/ins/vector/file_source.c
@@ -1,0 +1,55 @@
+int INS_VECTOR_FUNC(fread)(INS_VECTOR_TYPE *v, FILE *stream) {
+  const size_t size = v->size;
+  const size_t stride = v->stride;
+
+  const size_t elem_size = sizeof(INS_NUMERIC_TYPE);
+  size_t num_elems;
+
+  if (stride == 1) {
+    num_elems = fread(v->data, elem_size, size, stream);
+    if (num_elems != size) {
+      INS_ERROR("fread failed", INS_EFAILED);
+    }
+  } else {
+    size_t i;
+
+    // TODO(linh): Call `fread` inside a loop? What if the size of the
+    // vector is big, say, order of million elements?
+    for (i = 0; i < size; ++i) {
+      num_elems = fread(v->data + i * stride, elem_size, 1, stream);
+      if (num_elems != 1) {
+        INS_ERROR("fread failed", INS_EFAILED);
+      }
+    }
+  }
+
+  return INS_SUCCESS;
+}
+
+int INS_VECTOR_FUNC(fwrite)(const INS_VECTOR_TYPE *v, FILE *stream) {
+  const size_t size = v->size;
+  const size_t stride = v->stride;
+
+  const size_t elem_size = sizeof(INS_NUMERIC_TYPE);
+  size_t num_elems;
+
+  if (stride == 1) {
+    num_elems = fwrite(v->data, elem_size, size, stream);
+    if (num_elems != size) {
+      INS_ERROR("fwrite failed", INS_EFAILED);
+    }
+  } else {
+    size_t i;
+
+    // TODO(linh): Call `fwrite` inside a loop? What if the size of the
+    // vector is big, say, order of million elements?
+    for (i = 0; i < size; ++i) {
+      num_elems = fwrite(v->data + i * stride, elem_size, 1, stream);
+      if (num_elems != 1) {
+        INS_ERROR("fwrite failed", INS_EFAILED);
+      }
+    }
+  }
+
+  return INS_SUCCESS;
+}

--- a/internal/ins/vector/vector_double_file_test.c
+++ b/internal/ins/vector/vector_double_file_test.c
@@ -1,0 +1,124 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <ins/ins_vector.h>
+
+static void test_vector_fwrite_stride_one(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(3);
+
+  v->data[0] = 0.5;
+  v->data[1] = 2.0;
+  v->data[2] = 4.0;
+
+  FILE *file = fopen("vector_double_fwrite_stride_one.dat", "wb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fwrite(v, file);
+  assert_int_equal(status, INS_SUCCESS);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+static void test_vector_fwrite_stride_two(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(5);
+
+  v->data[0] = 0.5;
+  v->data[1] = -1.5;
+  v->data[2] = 2.0;
+  v->data[3] = 0.0;
+  v->data[4] = 4.0;
+
+  v->size = 3;
+  v->stride = 2;
+
+  FILE *file = fopen("vector_double_fwrite_stride_two.dat", "wb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fwrite(v, file);
+  assert_int_equal(status, INS_SUCCESS);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+static void test_vector_fread_stride_one(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(3);
+
+  FILE *file = fopen("vector_double_fwrite_stride_one.dat", "rb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fread(v, file);
+  assert_int_equal(status, INS_SUCCESS);
+
+  // check v's data
+  assert_double_equal(v->data[0], 0.5, 0.0);
+  assert_double_equal(v->data[1], 2.0, 0.0);
+  assert_double_equal(v->data[2], 4.0, 0.0);
+
+  // Check v's state
+  assert_int_equal(v->size, 3);
+  assert_int_equal(v->stride, 1);
+  assert_non_null(v->block);
+  assert_ptr_equal(v->block->data, v->data);
+  assert_int_equal(v->owner, 1);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+static void test_vector_fread_stride_two(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_calloc(5);
+
+  v->size = 3;
+  v->stride = 2;
+
+  FILE *file = fopen("vector_double_fwrite_stride_two.dat", "rb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fread(v, file);
+  assert_int_equal(status, INS_SUCCESS);
+
+  // Check v's elements
+  assert_double_equal(ins_vector_get(v, 0), 0.5, 0.0);
+  assert_double_equal(ins_vector_get(v, 1), 2.0, 0.0);
+  assert_double_equal(ins_vector_get(v, 2), 4.0, 0.0);
+
+  // Check v's data
+  assert_double_equal(v->data[0], 0.5, 0.0);
+  assert_double_equal(v->data[1], 0.0, 0.0);
+  assert_double_equal(v->data[2], 2.0, 0.0);
+  assert_double_equal(v->data[3], 0.0, 0.0);
+  assert_double_equal(v->data[4], 4.0, 0.0);
+
+  // Check v's state
+  assert_int_equal(v->size, 3);
+  assert_int_equal(v->stride, 2);
+  assert_non_null(v->block);
+  assert_ptr_equal(v->block->data, v->data);
+  assert_int_equal(v->owner, 1);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+int main(void) {
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_vector_fwrite_stride_one),
+    cmocka_unit_test(test_vector_fwrite_stride_two),
+    cmocka_unit_test(test_vector_fread_stride_one),
+    cmocka_unit_test(test_vector_fread_stride_two)
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/internal/ins/vector/vector_double_file_test.c
+++ b/internal/ins/vector/vector_double_file_test.c
@@ -112,12 +112,128 @@ static void test_vector_fread_stride_two(void **state) {
   ins_vector_free(v);
 }
 
+static void test_ins_vector_fprintf_stride_one(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(3);
+  v->data[0] = 0.125;
+  v->data[1] = 4.0;
+  v->data[2] = -2.45;
+
+  FILE *file = fopen("vector_double_fprintf_stride_one.dat", "wb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fprintf(v, file, "%g");
+  assert_int_equal(status, INS_SUCCESS);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+static void test_ins_vector_fprintf_stride_two(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(5);
+
+  v->data[0] = 0.125;
+  v->data[1] = -1.5;
+  v->data[2] = 4.0;
+  v->data[3] = 2.5;
+  v->data[4] = -2.45;
+
+  v->size = 3;
+  v->stride = 2;
+
+  FILE *file = fopen("vector_double_fprintf_stride_two.dat", "wb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fprintf(v, file, "%g");
+  assert_int_equal(status, INS_SUCCESS);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+static void test_ins_vector_fscanf_stride_one(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(3);
+
+  FILE *file = fopen("vector_double_fprintf_stride_one.dat", "rb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fscanf(v, file);
+  assert_int_equal(status, INS_SUCCESS);
+
+  // Check v's data
+  assert_double_equal(v->data[0], 0.125, 0.0);
+  assert_double_equal(v->data[1], 4.0, 0.0);
+  assert_double_equal(v->data[2], -2.45, 0.0);
+
+  // Check v's state
+  assert_int_equal(v->size, 3);
+  assert_int_equal(v->stride, 1);
+  assert_non_null(v->block);
+  assert_ptr_equal(v->block->data, v->data);
+  assert_int_equal(v->owner, 1);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
+static void test_ins_vector_fscanf_stride_two(void **state) {
+  (void) state;
+
+  ins_vector *v = ins_vector_alloc(5);
+
+  v->data[0] = 0.0;
+  v->data[1] = -1.5;
+  v->data[2] = 0.0;
+  v->data[3] = 2.5;
+  v->data[4] = 0.0;
+
+  v->size = 3;
+  v->stride = 2;
+
+  FILE *file = fopen("vector_double_fprintf_stride_two.dat", "rb");
+  assert_non_null(file);
+
+  const int status = ins_vector_fscanf(v, file);
+  assert_int_equal(status, INS_SUCCESS);
+
+  // Check v's elements
+  assert_double_equal(ins_vector_get(v, 0), 0.125, 0.0);
+  assert_double_equal(ins_vector_get(v, 1), 4.0, 0.0);
+  assert_double_equal(ins_vector_get(v, 2), -2.45, 0.0);
+
+  // Check v's data
+  assert_double_equal(v->data[0], 0.125, 0.0);
+  assert_double_equal(v->data[1], -1.5, 0.0);
+  assert_double_equal(v->data[2], 4.0, 0.0);
+  assert_double_equal(v->data[3], 2.5, 0.0);
+  assert_double_equal(v->data[4], -2.45, 0.0);
+
+  // Check v's state
+  assert_int_equal(v->size, 3);
+  assert_int_equal(v->stride, 2);
+  assert_non_null(v->block);
+  assert_ptr_equal(v->block->data, v->data);
+  assert_int_equal(v->owner, 1);
+
+  fclose(file);
+  ins_vector_free(v);
+}
+
 int main(void) {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_vector_fwrite_stride_one),
     cmocka_unit_test(test_vector_fwrite_stride_two),
     cmocka_unit_test(test_vector_fread_stride_one),
-    cmocka_unit_test(test_vector_fread_stride_two)
+    cmocka_unit_test(test_vector_fread_stride_two),
+    cmocka_unit_test(test_ins_vector_fprintf_stride_one),
+    cmocka_unit_test(test_ins_vector_fprintf_stride_two),
+    cmocka_unit_test(test_ins_vector_fscanf_stride_one),
+    cmocka_unit_test(test_ins_vector_fscanf_stride_two)
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
```c
// Reads into the vector `v` from the open stream `stream` in binary format.
// The vector `v` must be preallocated with the correct length since the
// function uses the size of `v` to determine how many bytes to read.
// The return value is `INS_SUCCESS` for success and `INS_EFAILED` if there
// was a problem reading from the file.
int ins_vector_fread(ins_vector *v, FILE *stream);

// Writes the elements of the vector `v` to the stream `stream` in binary
// format. The return value is `INS_SUCCESS` for success and `INS_EFAILED`
// if there was a problem writing to the file.
int ins_vector_fwrite(const ins_vector *v, FILE *stream);

// Writes the elements of the vector `v` line-by-line to the open stream
// `stream` using the format specifier `format`, which should be one of
// `%g`, `%e`, or `%f` formats for floating point numbers and `%d` for
// integers. The function returns `INS_SUCCESS` for success and `INS_EFAILED`
// if there was a problem writing to the file.
int ins_vector_fprintf(const ins_vector *v, FILE *stream, const char *format);

// Reads formatted data from the stream `stream` into the vector `v`. The
// vector `v` must be preallocated with the correct length since the function
// uses the size of `v` to determine how many bytes to read. The function
// returns `INS_SUCCESS` for success and `INS_EFAILED` if there was a problem
// reading from the file.
int ins_vector_fscanf(ins_vector *v, FILE *stream);
```